### PR TITLE
Remove core5compat, use QStringEncoder/Decoder with Qt6

### DIFF
--- a/SpellChecker.pro
+++ b/SpellChecker.pro
@@ -1,7 +1,4 @@
 QT      += core gui widgets
-greaterThan(QT_MAJOR_VERSION, 5) {
-  QT    += core5compat
-}
 
 TARGET   = SpellChecker
 TEMPLATE = app

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -68,7 +68,7 @@ void Dialog::checkSpelling() {
 
   QList<QTextEdit::ExtraSelection> esList;
 
-  // Don't call cursor.beginEditBlock(), as this prevents the rewdraw after
+  // Don't call cursor.beginEditBlock(), as this prevents the redraw after
   // changes to the content cursor.beginEditBlock();
   while (!cursor.atEnd()) {
     QCoreApplication::processEvents();

--- a/spellchecker.h
+++ b/spellchecker.h
@@ -4,8 +4,13 @@
 #include <QString>
 #include <QStringList>
 
-class Hunspell;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 class QTextCodec;
+#else
+#include <QStringDecoder>
+#include <QStringEncoder>
+#endif
+class Hunspell;
 
 class SpellChecker {
  public:
@@ -22,7 +27,12 @@ class SpellChecker {
   Hunspell *_hunspell;
   QString _userDictionary;
   QString _encoding;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QTextCodec *_codec;
+#else
+  QStringDecoder _decoder;
+  QStringEncoder _encoder;
+#endif
 };
 
 #endif // SPELLCHECKER_H 


### PR DESCRIPTION
Hi
as mentioned in 05f0e5b, adding core5compat was the fastest solution to add compatibility for Qt6. With this pull request I'm adding "pure Qt6" implementation without need for any Qt5 compatibility modules.